### PR TITLE
#205: Fix for highlight detection

### DIFF
--- a/bot/community/community.py
+++ b/bot/community/community.py
@@ -235,11 +235,11 @@ async def _check_if_already_highlight(highlight_channel: discord.TextChannel, me
         (discord.Message): The highlight message if one has already been posted recently.
     """
     async for message in highlight_channel.history(limit=int(const.LIMIT_HIGHLIGHT_LOOKUP)):
-        # Return a message id which can never be valid if the embed doesn't include a Jump URL.
-        original_message_id = message.embeds[0].url.split("/")[-1] if message.embeds[0].url else -1
+        if message.embeds and message.embeds[0].url:
+            original_message_id = message.embeds[0].url.split("/")[-1]
 
-        if int(original_message_id) == message_id:
-            return message
+            if int(original_message_id) == message_id:
+                return message
 
     return None
 


### PR DESCRIPTION
Check if messages have an embed and an URL and return `None` for the highlight message if not.