### PR TITLE
format command to format code in messages using clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ As the development progesses, more information about this project will be shared
 |---------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------:|
 | ![exchange-command](https://user-images.githubusercontent.com/49726903/93120394-98c00c80-f6c3-11ea-9714-6da7dc6d5b73.gif) | ![purge-command](https://user-images.githubusercontent.com/49726903/93122466-ce1a2980-f6c6-11ea-8eb9-f18d4785b176.gif) |
 
+[clang-format](https://clang.llvm.org/docs/ClangFormat.html) must be in the path for the `!format` command to work.
 ###### Robot made by [Freepik](http://www.freepik.com/) from [Flaticon](https://www.flaticon.com/).

--- a/bot/utility/utility.py
+++ b/bot/utility/utility.py
@@ -220,10 +220,13 @@ class UtilityCog(commands.Cog):
 
         """
         await ctx.message.delete()
-        if not code:
-            await self.howto_format(ctx)
-            return
-        code = " ".join(code) if ctx.message.reference is None else ctx.message.reference.resolved.content
+        if ctx.message.reference is None:
+            code = " ".join(code)
+            if not code:
+                await self.howto_format(ctx)
+                return
+        else:
+            code = ctx.message.reference.resolved.content
         code = code.replace(">", ">\n") # type: ignore # this forces everything after an include (e.g. `#include <foo>`) into a new line. otherwise, clang-format won't change the format of messages with everything in one line
         # mypy would erroneously find an error in the next two lines because it doesn't notice that at this point, `code` is always a str.
         # You can verify its correctness by renaming the variable `code` as assignment target in the previous and all subsequent lines

--- a/bot/utility/utility.py
+++ b/bot/utility/utility.py
@@ -221,7 +221,7 @@ class UtilityCog(commands.Cog):
         """
         await ctx.message.delete()
         if ctx.message.reference is None:
-            code = " ".join(code)
+            code = " ".join(code)   # type: ignore
             if not code:
                 await self.howto_format(ctx)
                 return

--- a/bot/utility/utility.py
+++ b/bot/utility/utility.py
@@ -209,7 +209,7 @@ class UtilityCog(commands.Cog):
         await user.send(content=content, embed=embed)
 
     @commands.command(name='format')
-    async def format(self, ctx: commands.Context, language: Optional[str], *code: str):
+    async def format(self, ctx: commands.Context, language: str, *code: str):
         """Handler for the `format` command. Formats the provided message using clang-format and prints it using markdown syntax highlighting
             Refer to the !howto format for an extended explanation of how to use it
         Args:
@@ -217,8 +217,6 @@ class UtilityCog(commands.Cog):
 
         """
         try:
-            if language is None:
-                raise Exception("No language provided")
             code = " ".join(code) if ctx.message.reference is None else ctx.message.reference.resolved.content
             # mypy would erroneously find an error in the next two lines because it doesn't notice that at this point, `code` is always a str.
             # You can verify its correctness by renaming the variable `code` as assignment target in the previous and all subsequent lines
@@ -248,7 +246,7 @@ class UtilityCog(commands.Cog):
                         + "Syntax: `!format <Sprachkürzel (1)> <Code (2)>`\n"
                         + "(1): Ändert nicht die Formatierung, sondern nur das Discord syntax highlighting. Z.B. `c++`, `java`, `py`, ...\n"
                         + "(2): Der zu formatierende Code. Anführungszeichen sind nicht notwendig.\n"
-                        + "Wird auf eine Nachricht geantwortet, so wird der Inhalt der referenzierten Nachricht formatiert. (1) ist in diesem Fall optional und standardmäßig `c++`, (2) ist optional und wird ignoriert. "
+                        + "Wird auf eine Nachricht geantwortet, so wird der Inhalt der referenzierten Nachricht formatiert. (2) ist in diesem Fall optional und wird ignoriert. "
         )
         await ctx.send(embed=embed)
 

--- a/bot/utility/utility.py
+++ b/bot/utility/utility.py
@@ -219,16 +219,17 @@ class UtilityCog(commands.Cog):
             language: The language abbreviation to highlight the resulting code with
 
         """
-        try:
-            code = " ".join(code) if ctx.message.reference is None else ctx.message.reference.resolved.content
-            code = code.replace(">", ">\n") # type: ignore # this forces everything after an include (e.g. `#include <foo>`) into a new line. otherwise, clang-format won't change the format of messages with everything in one line
-            # mypy would erroneously find an error in the next two lines because it doesn't notice that at this point, `code` is always a str.
-            # You can verify its correctness by renaming the variable `code` as assignment target in the previous and all subsequent lines
-            code = code.removeprefix("```").removeprefix("`").removesuffix("```").removesuffix("`")   # type: ignore # this allows the command to format single- and multiline code blocks
-            result = subprocess.run("clang-format", text=True, input=code.replace("```", "´´´"), check=True, capture_output=True)  # type: ignore
-            await ctx.send(content = f"```{language}\n{result.stdout}\n```")
-        except Exception:
+        await ctx.message.delete()
+        if not code:
             await self.howto_format(ctx)
+            return
+        code = " ".join(code) if ctx.message.reference is None else ctx.message.reference.resolved.content
+        code = code.replace(">", ">\n") # type: ignore # this forces everything after an include (e.g. `#include <foo>`) into a new line. otherwise, clang-format won't change the format of messages with everything in one line
+        # mypy would erroneously find an error in the next two lines because it doesn't notice that at this point, `code` is always a str.
+        # You can verify its correctness by renaming the variable `code` as assignment target in the previous and all subsequent lines
+        code = code.removeprefix("```").removeprefix("`").removesuffix("```").removesuffix("`")   # type: ignore # this allows the command to format single- and multiline code blocks
+        result = subprocess.run("clang-format", text=True, input=code.replace("```", "´´´"), check=True, capture_output=True)  # type: ignore
+        await ctx.send(content = f"Formatting requested by <@{ctx.message.author.id}> (ID:{ctx.message.author.id})\n```{language}\n{result.stdout}\n```", reference = ctx.message.reference)
 
 
     @howto.command(name='format', description="Code in Nachrichten formatieren lassen")


### PR DESCRIPTION
Also adds the appropriate !howto format command.
Closes #218 